### PR TITLE
Added extra request to registry/{package}/latest for .readmeText attribute

### DIFF
--- a/src/controllers/mainCtrl.js
+++ b/src/controllers/mainCtrl.js
@@ -4,10 +4,11 @@ angular.module('app').controller('MainCtrl', ['$scope', '$http', 'DataSrvc', '$l
   $scope.numLimit = 3;
 
   DataSrvc.getData(function(data) {
-    for (let item in data) {
+    var localData = data.data;
+    for (let item in localData) {
       if (item != '_updated'){
-        data[item].latest = data[item]['dist-tags'].latest
-        $scope.sourceData.push(data[item]);
+        localData[item].latest = localData[item]['dist-tags'].latest
+        $scope.sourceData.push(localData[item]);
       }
     }
     $scope.data= $scope.sourceData

--- a/src/controllers/repoCtrl.js
+++ b/src/controllers/repoCtrl.js
@@ -3,9 +3,13 @@ angular.module('app').controller('RepoCtrl', ['$scope', 'DataSrvc', '$routeParam
   $scope.readmeText = '';
 
   DataSrvc.getData(function (data) {
-    $scope.data = data[$routeParams.name];
-    $scope.readmeText = $scope.data.readmeText;
-    console.log($scope.readmeText);
+    var packageName = $routeParams.name;
+    $scope.data = data[packageName];
+
+    DataSrvc.getUrlData('https://cpmisc.smileupps.com/' + packageName + '/latest', function(data) {
+      $scope.readmeText = data.readmeText;
+      console.log($scope.readmeText);
+    });
   })
 
 }]);

--- a/src/controllers/repoCtrl.js
+++ b/src/controllers/repoCtrl.js
@@ -2,14 +2,23 @@ angular.module('app').controller('RepoCtrl', ['$scope', 'DataSrvc', '$routeParam
   $scope.sourceData = [];
   $scope.readmeText = '';
 
+  function getSiteUrl(uri) {
+    return uri.split('/',3).join('/')
+  }
   DataSrvc.getData(function (data) {
     var packageName = $routeParams.name;
-    $scope.data = data[packageName];
+    $scope.data = data.data[packageName];
 
-    DataSrvc.getUrlData('https://cpmisc.smileupps.com/' + packageName + '/latest', function(data) {
-      $scope.readmeText = data.readmeText;
-      console.log($scope.readmeText);
-    });
+    if (data.readmeText) {
+        $scope.readmeText = $scope.data.readmeText;
+    } else {
+      var packageLatest = getSiteUrl(data.config.url) + '/' + packageName + '/latest';
+
+      DataSrvc.getUrlData(packageLatest, function(data) {
+        $scope.readmeText = data.data.readmeText;
+        console.log($scope.readmeText);
+      });
+    }
   })
 
 }]);

--- a/src/services/dataSrvc.js
+++ b/src/services/dataSrvc.js
@@ -38,5 +38,16 @@ angular.module('app').factory('DataSrvc', ['$http', '$q', '$location', function 
           })
 
       },
+      getUrlData: function (url, cb) {
+        $http.get(url, { cache: true })
+          .then(function (data) {
+            console.log('SUCCESS : ', url)
+            cb(data.data);
+          })
+          .catch(function (data) {
+            console.log('ERROR : ', url);
+          })
+
+      },
     }
   }]);

--- a/src/services/dataSrvc.js
+++ b/src/services/dataSrvc.js
@@ -31,7 +31,7 @@ angular.module('app').factory('DataSrvc', ['$http', '$q', '$location', function 
         $http.get(url, { cache: true })
           .then(function (data) {
             console.log('SUCCESS')
-            cb(data.data);
+            cb(data);
           })
           .catch(function (data) {
             console.log('ERROR');
@@ -42,7 +42,7 @@ angular.module('app').factory('DataSrvc', ['$http', '$q', '$location', function 
         $http.get(url, { cache: true })
           .then(function (data) {
             console.log('SUCCESS : ', url)
-            cb(data.data);
+            cb(data);
           })
           .catch(function (data) {
             console.log('ERROR : ', url);


### PR DESCRIPTION
We have discovered the harder way that /-/all request to registry does not return .readmeText attribute,
but particular request for /:packageName/:version does return all attributes, so invoking subrequest for this attribute.